### PR TITLE
Emitting error when store isn't found

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ module.exports.restore = function (store) {
 	}, function (cb) {
 
 		if (!cache[store]) {
-			gutil.log('gulp-save', gutil.colors.red('cache for `'+ store +'` not found'));
+			this.emit('error', new gutil.PluginError('gulp-save', 'Cache for `'+ store +'` not found'));
+			cb();
+			return;
 		}
 
 		cache[store].forEach(function (file) {

--- a/test.js
+++ b/test.js
@@ -100,3 +100,31 @@ it('should cache stream and restore it with custom options', function (cb) {
 
 	startStream.end();
 });
+
+it('should emit error when store is not found', function (cb) {
+	var startStream = start();
+	var startCache = save('foo');
+	var transformStream = transform();
+	var endStream = end();
+	var restoreCache = save.restore('bar');
+
+	startStream.pipe(startCache)
+			 .pipe(transformStream)
+			 .pipe(restoreCache)
+			 .on('error', function (err) {
+				cb();
+			 })
+			 .pipe(endStream);
+
+	endStream.on('end', function () {
+		throw new Error('Should have thrown');
+	});
+
+	startStream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/file.js',
+		contents: new Buffer('unicorns')
+	}));
+
+	startStream.end();
+});


### PR DESCRIPTION
`restore` should emit an error, and not just log the problem, when a store isn't found in the cache, so that `.on('error', ...)` can be used.

This also solve the problem of missing stores when the stream contains no files.